### PR TITLE
Add Sphinx docstrings and type hints for validation layer

### DIFF
--- a/cfb_data/cfb_data/base/validation/__init__.py
+++ b/cfb_data/cfb_data/base/validation/__init__.py
@@ -1,0 +1,1 @@
+from .validation_api import CFBDValidationAPI

--- a/cfb_data/cfb_data/base/validation/validation_api.py
+++ b/cfb_data/cfb_data/base/validation/validation_api.py
@@ -1,0 +1,40 @@
+"""Validation helpers for CFBD API responses."""
+
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+
+from pydantic import BaseModel
+
+from cfb_data.base.api.base_api import CFBDAPIBase
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class CFBDValidationAPI(CFBDAPIBase):
+    """Base API client that validates responses using Pydantic models."""
+
+    async def make_request_validated(
+        self,
+        path: str,
+        model: Type[T],
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Union[T, List[T]]:
+        """Make a request and validate the JSON response.
+
+        :param path: API endpoint path to request
+        :type path: str
+        :param model: Pydantic model class used for validation
+        :type model: Type[T]
+        :param params: Optional query parameters for the request
+        :type params: Optional[Dict[str, Any]]
+        :return: Validated model instance or list of instances
+        :rtype: Union[T, List[T]]
+        :raises TypeError: If the returned data is not a ``list`` or ``dict``
+        """
+        data: Union[List[Any], Dict[str, Any]] = await super().make_request(
+            path, params
+        )
+        if isinstance(data, list):
+            return [model.model_validate(item) for item in data]
+        if isinstance(data, dict):
+            return model.model_validate(data)
+        raise TypeError("Response data must be list or dict")

--- a/cfb_data/cfb_data/game/validation/__init__.py
+++ b/cfb_data/cfb_data/game/validation/__init__.py
@@ -1,0 +1,1 @@
+from .game_validation import CFBDGamesValidationAPI

--- a/cfb_data/cfb_data/game/validation/game_validation.py
+++ b/cfb_data/cfb_data/game/validation/game_validation.py
@@ -1,0 +1,120 @@
+"""Validation wrappers for game endpoints."""
+
+from typing import Any, Dict, List
+
+from cfb_data.base.validation.validation_api import CFBDValidationAPI
+from cfb_data.game.api.game_api import CFBDGamesAPI
+from cfb_data.game.models.pydantic.responses import (
+    CalendarWeek,
+    Game,
+    GameMedia,
+    GameWeather,
+    PlayerGameStats,
+    TeamGameStats,
+    TeamRecords,
+    AdvancedBoxScore,
+)
+
+
+class CFBDGamesValidationAPI(CFBDGamesAPI, CFBDValidationAPI):
+    """Games API with additional response validation."""
+
+    async def get_games_validated(self, params: Dict[str, Any]) -> List[Game]:
+        """Return validated games for the given parameters.
+
+        :param params: Query parameters to pass to ``/games``
+        :type params: Dict[str, Any]
+        :return: List of validated :class:`Game` models
+        :rtype: List[Game]
+        """
+        data: List[Dict[str, Any]] = await self._get_games(params)
+        return [Game.model_validate(item) for item in data]
+
+    async def get_team_records_validated(
+        self, params: Dict[str, Any]
+    ) -> List[TeamRecords]:
+        """Return validated team records.
+
+        :param params: Query parameters to pass to ``/records``
+        :type params: Dict[str, Any]
+        :return: List of validated :class:`TeamRecords` models
+        :rtype: List[TeamRecords]
+        """
+        data: List[Dict[str, Any]] = await self._get_team_records(params)
+        return [TeamRecords.model_validate(item) for item in data]
+
+    async def get_calendar_validated(
+        self, params: Dict[str, Any]
+    ) -> List[CalendarWeek]:
+        """Return validated calendar weeks.
+
+        :param params: Query parameters for ``/calendar``
+        :type params: Dict[str, Any]
+        :return: List of validated :class:`CalendarWeek` models
+        :rtype: List[CalendarWeek]
+        """
+        data: List[Dict[str, Any]] = await self._get_calendar(params)
+        return [CalendarWeek.model_validate(item) for item in data]
+
+    async def get_game_media_validated(self, params: Dict[str, Any]) -> List[GameMedia]:
+        """Return validated game media information.
+
+        :param params: Query parameters for ``/games/media``
+        :type params: Dict[str, Any]
+        :return: List of validated :class:`GameMedia` models
+        :rtype: List[GameMedia]
+        """
+        data: List[Dict[str, Any]] = await self._get_game_media(params)
+        return [GameMedia.model_validate(item) for item in data]
+
+    async def get_game_weather_validated(
+        self, params: Dict[str, Any]
+    ) -> List[GameWeather]:
+        """Return validated game weather information.
+
+        :param params: Query parameters for ``/games/weather``
+        :type params: Dict[str, Any]
+        :return: List of validated :class:`GameWeather` models
+        :rtype: List[GameWeather]
+        """
+        data: List[Dict[str, Any]] = await self._get_game_weather(params)
+        return [GameWeather.model_validate(item) for item in data]
+
+    async def get_player_game_stats_validated(
+        self, params: Dict[str, Any]
+    ) -> List[PlayerGameStats]:
+        """Return validated player statistics for each game.
+
+        :param params: Query parameters for ``/games/players``
+        :type params: Dict[str, Any]
+        :return: List of validated :class:`PlayerGameStats` models
+        :rtype: List[PlayerGameStats]
+        """
+        data: List[Dict[str, Any]] = await self._get_player_game_stats(params)
+        return [PlayerGameStats.model_validate(item) for item in data]
+
+    async def get_team_game_stats_validated(
+        self, params: Dict[str, Any]
+    ) -> List[TeamGameStats]:
+        """Return validated team statistics for each game.
+
+        :param params: Query parameters for ``/games/teams``
+        :type params: Dict[str, Any]
+        :return: List of validated :class:`TeamGameStats` models
+        :rtype: List[TeamGameStats]
+        """
+        data: List[Dict[str, Any]] = await self._get_team_game_stats(params)
+        return [TeamGameStats.model_validate(item) for item in data]
+
+    async def get_box_scores_validated(
+        self, params: Dict[str, Any]
+    ) -> AdvancedBoxScore:
+        """Return validated advanced box score for a game.
+
+        :param params: Query parameters for ``/games/box/advanced``
+        :type params: Dict[str, Any]
+        :return: Parsed :class:`AdvancedBoxScore` model
+        :rtype: AdvancedBoxScore
+        """
+        data: Dict[str, Any] = await self._get_box_scores(params)
+        return AdvancedBoxScore.model_validate(data)

--- a/tests/base/validation/test_validation_api.py
+++ b/tests/base/validation/test_validation_api.py
@@ -1,0 +1,53 @@
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, "cfb_data")
+
+# Provide a minimal aiohttp stub for import resolution
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    sys.modules["aiohttp"] = aiohttp_stub
+
+import pytest
+from pydantic import ValidationError
+
+from cfb_data.base.validation import CFBDValidationAPI
+from cfb_data.game.models.pydantic.responses import CalendarWeek
+
+
+class DummyValidationAPI(CFBDValidationAPI):
+    """Subclass to expose validation helpers for testing."""
+
+    def __init__(self) -> None:
+        super().__init__(api_key="fake")
+
+
+def run(coro):
+    """Execute a coroutine for synchronous test code."""
+
+    return asyncio.run(coro)
+
+
+def test_make_request_validated_returns_models():
+    api = DummyValidationAPI()
+    sample = {
+        "season": 2024,
+        "week": 1,
+        "season_type": "regular",
+        "first_game_start": "2024-08-01T00:00:00Z",
+        "last_game_start": "2024-08-02T00:00:00Z",
+    }
+    api._make_request = AsyncMock(return_value=[sample])
+    result = run(api.make_request_validated("/calendar", CalendarWeek))
+    api._make_request.assert_awaited_once_with("/calendar", None)
+    assert isinstance(result, list)
+    assert result[0].season == 2024
+
+
+def test_make_request_validated_raises_on_invalid():
+    api = DummyValidationAPI()
+    api._make_request = AsyncMock(return_value=[{"season": 2024}])
+    with pytest.raises(ValidationError):
+        run(api.make_request_validated("/calendar", CalendarWeek))

--- a/tests/game/validation/test_game_validation.py
+++ b/tests/game/validation/test_game_validation.py
@@ -1,0 +1,52 @@
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, "cfb_data")
+
+# Provide a minimal aiohttp stub for import resolution
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    sys.modules["aiohttp"] = aiohttp_stub
+
+import pytest
+from pydantic import ValidationError
+
+from cfb_data.game.validation import CFBDGamesValidationAPI
+
+
+class DummyGamesValidationAPI(CFBDGamesValidationAPI):
+    """Expose protected validation methods for testing."""
+
+    def __init__(self) -> None:
+        super().__init__(api_key="fake")
+
+
+def run(coro):
+    """Execute a coroutine for synchronous test code."""
+
+    return asyncio.run(coro)
+
+
+def test_get_calendar_validated_returns_models():
+    api = DummyGamesValidationAPI()
+    sample = {
+        "season": 2024,
+        "week": 1,
+        "season_type": "regular",
+        "first_game_start": "2024-08-01T00:00:00Z",
+        "last_game_start": "2024-08-02T00:00:00Z",
+    }
+    api._get_calendar = AsyncMock(return_value=[sample])
+    result = run(api.get_calendar_validated({"year": 2024}))
+    api._get_calendar.assert_awaited_once_with({"year": 2024})
+    assert isinstance(result, list)
+    assert result[0].week == 1
+
+
+def test_get_calendar_validated_raises_on_invalid():
+    api = DummyGamesValidationAPI()
+    api._get_calendar = AsyncMock(return_value=[{"season": 2024}])
+    with pytest.raises(ValidationError):
+        run(api.get_calendar_validated({"year": 2024}))


### PR DESCRIPTION
## Summary
- add missing Sphinx-style docstrings and variable annotations for new validation layer
- document helper classes in validation tests

## Testing
- `ruff check cfb_data/cfb_data/base/validation/validation_api.py cfb_data/cfb_data/game/validation/game_validation.py tests/base/validation/test_validation_api.py tests/game/validation/test_game_validation.py`
- `pytest -q`
