### PR TITLE
Add pandas layer with pandera validation

### DIFF
--- a/cfb_data/cfb_data/base/pandas/__init__.py
+++ b/cfb_data/cfb_data/base/pandas/__init__.py
@@ -1,0 +1,5 @@
+"""Pandas utilities for CFBD API."""
+
+from .pandas_api import CFBDPanderaAPI
+
+__all__ = ["CFBDPanderaAPI"]

--- a/cfb_data/cfb_data/base/pandas/pandas_api.py
+++ b/cfb_data/cfb_data/base/pandas/pandas_api.py
@@ -1,0 +1,49 @@
+"""Pandas wrapper for validated CFBD API responses."""
+
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+
+import pandas as pd
+from cfb_data.base.validation.validation_api import CFBDValidationAPI
+from pandera import DataFrameModel
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class CFBDPanderaAPI(CFBDValidationAPI):
+    """Base API client that returns Pandas DataFrames validated with pandera."""
+
+    async def make_request_pandas(
+        self,
+        path: str,
+        model: Type[T],
+        schema: Type[DataFrameModel],
+        params: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        """Make a request and return a validated :class:`pandas.DataFrame`.
+
+        The JSON response is first parsed into ``model`` using ``pydantic`` and
+        then coerced into a DataFrame validated against ``schema``.
+
+        :param path: API endpoint path to request
+        :type path: str
+        :param model: Pydantic model class used for validation
+        :type model: Type[T]
+        :param schema: Pandera schema model for DataFrame validation
+        :type schema: Type[DataFrameModel]
+        :param params: Optional query parameters for the request
+        :type params: Optional[Dict[str, Any]]
+        :return: Validated DataFrame containing the response data
+        :rtype: pandas.DataFrame
+        """
+        data: Union[List[T], T] = await self.make_request_validated(path, model, params)
+
+        records: List[Dict[str, Any]]
+        if isinstance(data, list):
+            records = [d.model_dump() for d in data]
+        else:
+            records = [data.model_dump()]
+
+        df: pd.DataFrame = pd.DataFrame(records)
+        validated_df: pd.DataFrame = schema.validate(df)
+        return validated_df

--- a/cfb_data/cfb_data/game/models/pandera/responses.py
+++ b/cfb_data/cfb_data/game/models/pandera/responses.py
@@ -2,17 +2,18 @@
 College Football Data API - Pandera Schema Models for Games Section
 """
 
-import pandera as pa
-from pandera.typing import Series
-from pandera import Field, SchemaModel
-from typing import List, Optional, Dict, Any
 from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import pandera as pa
+from pandera import DataFrameModel, Field
+from pandera.typing import Series
 
 
 # -------------------------------------------------------------------
 # /games endpoint
 # -------------------------------------------------------------------
-class GameSchema(SchemaModel):
+class GameSchema(DataFrameModel):
     """
     Schema for /games endpoint.
     """
@@ -52,6 +53,8 @@ class GameSchema(SchemaModel):
     notes: Series[Optional[str]] = Field(nullable=True)
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
@@ -59,7 +62,7 @@ class GameSchema(SchemaModel):
 # -------------------------------------------------------------------
 # /calendar endpoint
 # -------------------------------------------------------------------
-class CalendarWeekSchema(SchemaModel):
+class CalendarWeekSchema(DataFrameModel):
     """
     Schema for /calendar endpoint.
     """
@@ -71,6 +74,8 @@ class CalendarWeekSchema(SchemaModel):
     last_game_start: Series[datetime] = Field()
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
@@ -78,7 +83,7 @@ class CalendarWeekSchema(SchemaModel):
 # -------------------------------------------------------------------
 # /games/media endpoint
 # -------------------------------------------------------------------
-class GameMediaSchema(SchemaModel):
+class GameMediaSchema(DataFrameModel):
     """
     Schema for /games/media endpoint.
     """
@@ -101,6 +106,8 @@ class GameMediaSchema(SchemaModel):
     outlet: Series[Optional[str]] = Field(nullable=True)
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
@@ -108,7 +115,7 @@ class GameMediaSchema(SchemaModel):
 # -------------------------------------------------------------------
 # /games/weather endpoint
 # -------------------------------------------------------------------
-class GameWeatherSchema(SchemaModel):
+class GameWeatherSchema(DataFrameModel):
     """
     Schema for /games/weather endpoint.
     """
@@ -133,6 +140,8 @@ class GameWeatherSchema(SchemaModel):
     weather_condition: Series[Optional[str]] = Field(nullable=True)
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
@@ -140,7 +149,7 @@ class GameWeatherSchema(SchemaModel):
 # -------------------------------------------------------------------
 # /records endpoint
 # -------------------------------------------------------------------
-class TeamRecordsSchema(SchemaModel):
+class TeamRecordsSchema(DataFrameModel):
     """
     Schema for /records endpoint.
     """
@@ -157,6 +166,8 @@ class TeamRecordsSchema(SchemaModel):
     away_games: Series[Optional[Dict[str, int]]] = Field(nullable=True)
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
@@ -164,7 +175,7 @@ class TeamRecordsSchema(SchemaModel):
 # -------------------------------------------------------------------
 # /games/players endpoint
 # -------------------------------------------------------------------
-class PlayerGameStatsSchema(SchemaModel):
+class PlayerGameStatsSchema(DataFrameModel):
     """
     Schema for /games/players endpoint.
     """
@@ -179,6 +190,8 @@ class PlayerGameStatsSchema(SchemaModel):
     defensive: Series[Optional[List[Dict[str, Any]]]] = Field(nullable=True)
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
@@ -186,7 +199,7 @@ class PlayerGameStatsSchema(SchemaModel):
 # -------------------------------------------------------------------
 # /games/teams endpoint
 # -------------------------------------------------------------------
-class TeamGameStatsSchema(SchemaModel):
+class TeamGameStatsSchema(DataFrameModel):
     """
     Schema for /games/teams endpoint.
     """
@@ -215,6 +228,8 @@ class TeamGameStatsSchema(SchemaModel):
     possession_time: Series[Optional[str]] = Field(nullable=True)
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
@@ -222,7 +237,7 @@ class TeamGameStatsSchema(SchemaModel):
 # -------------------------------------------------------------------
 # /scoreboard endpoint
 # -------------------------------------------------------------------
-class GameLineSchema(SchemaModel):
+class GameLineSchema(DataFrameModel):
     """
     Sub-schema for the 'line' field in /scoreboard.
     """
@@ -232,11 +247,13 @@ class GameLineSchema(SchemaModel):
     over_under: Series[float] = Field()
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True
 
 
-class ScoreboardSchema(SchemaModel):
+class ScoreboardSchema(DataFrameModel):
     """
     Schema for /scoreboard endpoint.
     """
@@ -255,5 +272,7 @@ class ScoreboardSchema(SchemaModel):
     line: Series[Optional[Dict[str, float]]] = Field(nullable=True)
 
     class Config:
+        """Pandera configuration."""
+
         coerce = True
         strict = True

--- a/cfb_data/cfb_data/game/pandas/__init__.py
+++ b/cfb_data/cfb_data/game/pandas/__init__.py
@@ -1,0 +1,5 @@
+"""Pandas wrappers for game endpoints."""
+
+from .game_pandas import CFBDGamesPandasAPI
+
+__all__ = ["CFBDGamesPandasAPI"]

--- a/cfb_data/cfb_data/game/pandas/game_pandas.py
+++ b/cfb_data/cfb_data/game/pandas/game_pandas.py
@@ -1,0 +1,119 @@
+"""Pandas-returning wrappers for game endpoints."""
+
+from typing import Any, Dict
+
+import pandas as pd
+from cfb_data.base.pandas.pandas_api import CFBDPanderaAPI
+from cfb_data.game.models.pandera.responses import (
+    CalendarWeekSchema,
+    GameMediaSchema,
+    GameSchema,
+    GameWeatherSchema,
+    PlayerGameStatsSchema,
+    TeamGameStatsSchema,
+    TeamRecordsSchema,
+)
+from cfb_data.game.models.pydantic.responses import (
+    CalendarWeek,
+    Game,
+    GameMedia,
+    GameWeather,
+    PlayerGameStats,
+    TeamGameStats,
+    TeamRecords,
+)
+from cfb_data.game.validation.game_validation import CFBDGamesValidationAPI
+
+
+class CFBDGamesPandasAPI(CFBDGamesValidationAPI, CFBDPanderaAPI):
+    """Games API that returns ``pandas.DataFrame`` objects."""
+
+    async def get_games_df(self, params: Dict[str, Any]) -> pd.DataFrame:
+        """Return games as a validated DataFrame.
+
+        :param params: Query parameters passed to the ``/games`` endpoint
+        :type params: Dict[str, Any]
+        :return: Validated DataFrame of games
+        :rtype: pandas.DataFrame
+        """
+        return await self.make_request_pandas(
+            self._get_games._api_path, Game, GameSchema, params
+        )
+
+    async def get_team_records_df(self, params: Dict[str, Any]) -> pd.DataFrame:
+        """Return team records as a validated DataFrame.
+
+        :param params: Query parameters passed to ``/records``
+        :type params: Dict[str, Any]
+        :return: Validated DataFrame of team records
+        :rtype: pandas.DataFrame
+        """
+        return await self.make_request_pandas(
+            self._get_team_records._api_path, TeamRecords, TeamRecordsSchema, params
+        )
+
+    async def get_calendar_df(self, params: Dict[str, Any]) -> pd.DataFrame:
+        """Return calendar weeks as a validated DataFrame.
+
+        :param params: Query parameters passed to ``/calendar``
+        :type params: Dict[str, Any]
+        :return: Validated DataFrame of calendar weeks
+        :rtype: pandas.DataFrame
+        """
+        return await self.make_request_pandas(
+            self._get_calendar._api_path, CalendarWeek, CalendarWeekSchema, params
+        )
+
+    async def get_game_media_df(self, params: Dict[str, Any]) -> pd.DataFrame:
+        """Return game media information as a validated DataFrame.
+
+        :param params: Query parameters passed to ``/games/media``
+        :type params: Dict[str, Any]
+        :return: Validated DataFrame of game media
+        :rtype: pandas.DataFrame
+        """
+        return await self.make_request_pandas(
+            self._get_game_media._api_path, GameMedia, GameMediaSchema, params
+        )
+
+    async def get_game_weather_df(self, params: Dict[str, Any]) -> pd.DataFrame:
+        """Return game weather information as a validated DataFrame.
+
+        :param params: Query parameters passed to ``/games/weather``
+        :type params: Dict[str, Any]
+        :return: Validated DataFrame of game weather
+        :rtype: pandas.DataFrame
+        """
+        return await self.make_request_pandas(
+            self._get_game_weather._api_path, GameWeather, GameWeatherSchema, params
+        )
+
+    async def get_player_game_stats_df(self, params: Dict[str, Any]) -> pd.DataFrame:
+        """Return player stats for each game as a validated DataFrame.
+
+        :param params: Query parameters passed to ``/games/players``
+        :type params: Dict[str, Any]
+        :return: Validated DataFrame of player statistics
+        :rtype: pandas.DataFrame
+        """
+        return await self.make_request_pandas(
+            self._get_player_game_stats._api_path,
+            PlayerGameStats,
+            PlayerGameStatsSchema,
+            params,
+        )
+
+    async def get_team_game_stats_df(self, params: Dict[str, Any]) -> pd.DataFrame:
+        """Return team stats for each game as a validated DataFrame.
+
+        :param params: Query parameters passed to ``/games/teams``
+        :type params: Dict[str, Any]
+        :return: Validated DataFrame of team statistics
+        :rtype: pandas.DataFrame
+        """
+        return await self.make_request_pandas(
+            self._get_team_game_stats._api_path,
+            TeamGameStats,
+            TeamGameStatsSchema,
+            params,
+        )

--- a/tests/base/pandas/test_pandas_api.py
+++ b/tests/base/pandas/test_pandas_api.py
@@ -1,0 +1,77 @@
+"""Tests for the pandas validation layer."""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pandas as pd
+
+sys.path.insert(0, "cfb_data")
+
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    sys.modules["aiohttp"] = aiohttp_stub
+
+import pandera as pa
+import pytest
+from cfb_data.base.pandas import CFBDPanderaAPI
+from cfb_data.game.models.pandera.responses import CalendarWeekSchema
+from cfb_data.game.models.pydantic.responses import CalendarWeek
+
+
+class DummyPandasAPI(CFBDPanderaAPI):
+    """Expose pandas helper for testing."""
+
+    def __init__(self) -> None:
+        """Initialize the dummy API with a fake key."""
+
+        super().__init__(api_key="fake")
+
+
+def run(coro):
+    """Execute a coroutine for synchronous test code.
+
+    :param coro: Coroutine to execute
+    :type coro: Coroutine
+    :return: Result of the coroutine
+    :rtype: Any
+    """
+
+    return asyncio.run(coro)
+
+
+def test_make_request_pandas_returns_dataframe():
+    """Ensure DataFrame is returned for valid input."""
+
+    api = DummyPandasAPI()
+    sample = {
+        "season": 2024,
+        "week": 1,
+        "season_type": "regular",
+        "first_game_start": "2024-08-01T00:00:00Z",
+        "last_game_start": "2024-08-02T00:00:00Z",
+    }
+    model = CalendarWeek.model_validate(sample)
+    api.make_request_validated = AsyncMock(return_value=[model])
+    df = run(api.make_request_pandas("/calendar", CalendarWeek, CalendarWeekSchema))
+    api.make_request_validated.assert_awaited_once_with("/calendar", CalendarWeek, None)
+    assert isinstance(df, pd.DataFrame)
+    assert df.loc[0, "week"] == 1
+
+
+def test_make_request_pandas_raises_on_schema_error():
+    """Ensure a schema error is raised for invalid data."""
+
+    api = DummyPandasAPI()
+    bad_sample = {
+        "season": 2024,
+        "week": -1,
+        "season_type": "regular",
+        "first_game_start": "2024-08-01T00:00:00Z",
+        "last_game_start": "2024-08-02T00:00:00Z",
+    }
+    model = CalendarWeek.model_validate(bad_sample)
+    api.make_request_validated = AsyncMock(return_value=[model])
+    with pytest.raises(pa.errors.SchemaError):
+        run(api.make_request_pandas("/calendar", CalendarWeek, CalendarWeekSchema))

--- a/tests/game/pandas/test_game_pandas.py
+++ b/tests/game/pandas/test_game_pandas.py
@@ -1,0 +1,77 @@
+"""Tests for the games pandas API layer."""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pandera as pa
+import pytest
+
+sys.path.insert(0, "cfb_data")
+
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    sys.modules["aiohttp"] = aiohttp_stub
+
+from cfb_data.game.pandas import CFBDGamesPandasAPI
+
+
+class DummyGamesPandasAPI(CFBDGamesPandasAPI):
+    """Expose pandas methods for testing."""
+
+    def __init__(self) -> None:
+        """Initialize the dummy games API with a fake key."""
+
+        super().__init__(api_key="fake")
+
+
+def run(coro):
+    """Execute a coroutine for synchronous test code.
+
+    :param coro: Coroutine to execute
+    :type coro: Coroutine
+    :return: Result of the coroutine
+    :rtype: Any
+    """
+
+    return asyncio.run(coro)
+
+
+def test_get_calendar_df_returns_dataframe():
+    """Return DataFrame for valid calendar data."""
+
+    sample = {
+        "season": 2024,
+        "week": 1,
+        "season_type": "regular",
+        "first_game_start": "2024-08-01T00:00:00Z",
+        "last_game_start": "2024-08-02T00:00:00Z",
+    }
+    mocked = AsyncMock(return_value=[sample])
+    mocked._api_path = CFBDGamesPandasAPI._get_calendar._api_path
+    with patch.object(CFBDGamesPandasAPI, "_get_calendar", mocked):
+        api = DummyGamesPandasAPI()
+        df = run(api.get_calendar_df({"year": 2024}))
+        mocked.assert_awaited_once_with({"year": 2024})
+        assert isinstance(df, pd.DataFrame)
+        assert df.loc[0, "week"] == 1
+
+
+def test_get_calendar_df_schema_error():
+    """Raise schema error for invalid calendar data."""
+
+    bad_sample = {
+        "season": 2024,
+        "week": -1,
+        "season_type": "regular",
+        "first_game_start": "2024-08-01T00:00:00Z",
+        "last_game_start": "2024-08-02T00:00:00Z",
+    }
+    mocked = AsyncMock(return_value=[bad_sample])
+    mocked._api_path = CFBDGamesPandasAPI._get_calendar._api_path
+    with patch.object(CFBDGamesPandasAPI, "_get_calendar", mocked):
+        api = DummyGamesPandasAPI()
+        with pytest.raises(pa.errors.SchemaError):
+            run(api.get_calendar_df({"year": 2024}))


### PR DESCRIPTION
## Summary
- add CFBDPanderaAPI with `make_request_pandas` helper
- implement games pandas API returning validated dataframes
- provide pandera config docstrings in models
- add unit tests for the pandas layer

## Testing
- `pre-commit run --files cfb_data/cfb_data/base/pandas/pandas_api.py cfb_data/cfb_data/game/pandas/game_pandas.py tests/base/pandas/test_pandas_api.py tests/game/pandas/test_game_pandas.py cfb_data/cfb_data/game/models/pandera/responses.py`
- `pytest -q`