### PR TITLE
Add drives API with validation and pandas support

### DIFF
--- a/cfb_data/cfb_data/drives/__init__.py
+++ b/cfb_data/cfb_data/drives/__init__.py
@@ -1,0 +1,11 @@
+"""High-level package exports for the drives module."""
+
+from .api import CFBDDrivesAPI
+from .pandas import CFBDDrivesPandasAPI
+from .validation import CFBDDrivesValidationAPI
+
+__all__ = [
+    "CFBDDrivesAPI",
+    "CFBDDrivesValidationAPI",
+    "CFBDDrivesPandasAPI",
+]

--- a/cfb_data/cfb_data/drives/api/__init__.py
+++ b/cfb_data/cfb_data/drives/api/__init__.py
@@ -1,0 +1,5 @@
+"""Export :class:`CFBDDrivesAPI`."""
+
+from .drives_api import CFBDDrivesAPI
+
+__all__ = ["CFBDDrivesAPI"]

--- a/cfb_data/cfb_data/drives/api/drives_api.py
+++ b/cfb_data/cfb_data/drives/api/drives_api.py
@@ -1,0 +1,31 @@
+"""Drive endpoint handlers for the CFBD API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from cfb_data.base.api.base_api import CFBDAPIBase, route
+from cfb_data.drives.models.pandera.responses import DriveSchema
+from cfb_data.drives.models.pydantic.responses import Drive
+
+
+class CFBDDrivesAPI(CFBDAPIBase):
+    """Drives endpoint for the College Football Data API."""
+
+    @route("/drives", response_model=Drive, dataframe_schema=DriveSchema)
+    async def _get_drives(self, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Retrieve historical drive data.
+
+        :param params: Query parameters including year (required) and optional
+            filters such as week, team, offense, defense, conference, and
+            classification.
+        :type params: Dict[str, Any]
+        :return: List of drive dictionaries.
+        :rtype: List[Dict[str, Any]]
+        :raises ValueError: If the required ``year`` parameter is missing.
+        """
+
+        if "year" not in params:
+            raise ValueError("year parameter is required for /drives endpoint")
+
+        return await self._make_request("/drives", params)

--- a/cfb_data/cfb_data/drives/models/pandera/__init__.py
+++ b/cfb_data/cfb_data/drives/models/pandera/__init__.py
@@ -1,0 +1,1 @@
+"""Exports for drives Pandera models."""

--- a/cfb_data/cfb_data/drives/models/pandera/responses.py
+++ b/cfb_data/cfb_data/drives/models/pandera/responses.py
@@ -1,0 +1,42 @@
+"""Pandera schema models for drives endpoint."""
+
+from typing import Dict, Optional
+
+import pandera as pa
+from pandera import DataFrameModel, Field
+from pandera.typing import Series
+
+
+class DriveSchema(DataFrameModel):
+    """Schema for `/drives` endpoint."""
+
+    offense: Series[str] = Field()
+    offense_conference: Series[str] = Field(nullable=True)
+    defense: Series[str] = Field()
+    defense_conference: Series[str] = Field(nullable=True)
+    game_id: Series[int] = Field(ge=0)
+    id: Series[str] = Field()
+    drive_number: Series[int] = Field(nullable=True, ge=0)
+    scoring: Series[bool] = Field()
+    start_period: Series[int] = Field(ge=0)
+    start_yardline: Series[int] = Field(ge=0)
+    start_yards_to_goal: Series[int] = Field(ge=0)
+    start_time: Series[Dict[str, int]] = Field()
+    end_period: Series[int] = Field(ge=0)
+    end_yardline: Series[int] = Field(ge=0)
+    end_yards_to_goal: Series[int] = Field(ge=0)
+    end_time: Series[Dict[str, int]] = Field()
+    plays: Series[int] = Field(ge=0)
+    yards: Series[int] = Field()
+    drive_result: Series[str] = Field()
+    is_home_offense: Series[bool] = Field()
+    start_offense_score: Series[int] = Field(ge=0)
+    start_defense_score: Series[int] = Field(ge=0)
+    end_offense_score: Series[int] = Field(ge=0)
+    end_defense_score: Series[int] = Field(ge=0)
+
+    class Config:
+        """Pandera configuration."""
+
+        coerce = True
+        strict = True

--- a/cfb_data/cfb_data/drives/models/pydantic/__init__.py
+++ b/cfb_data/cfb_data/drives/models/pydantic/__init__.py
@@ -1,0 +1,1 @@
+"""Exports for drives Pydantic models."""

--- a/cfb_data/cfb_data/drives/models/pydantic/responses.py
+++ b/cfb_data/cfb_data/drives/models/pydantic/responses.py
@@ -1,0 +1,43 @@
+"""Pydantic models for drives endpoint responses."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class DriveTime(BaseModel):
+    """Time remaining in a period."""
+
+    seconds: Optional[int] = None
+    minutes: Optional[int] = None
+
+
+class Drive(BaseModel):
+    """Drive data model for `/drives` endpoint."""
+
+    offense: str
+    offense_conference: Optional[str] = None
+    defense: str
+    defense_conference: Optional[str] = None
+    game_id: int
+    id: str
+    drive_number: Optional[int] = None
+    scoring: bool
+    start_period: int
+    start_yardline: int
+    start_yards_to_goal: int
+    start_time: DriveTime
+    end_period: int
+    end_yardline: int
+    end_yards_to_goal: int
+    end_time: DriveTime
+    plays: int
+    yards: int
+    drive_result: str
+    is_home_offense: bool
+    start_offense_score: int
+    start_defense_score: int
+    end_offense_score: int
+    end_defense_score: int

--- a/cfb_data/cfb_data/drives/pandas/__init__.py
+++ b/cfb_data/cfb_data/drives/pandas/__init__.py
@@ -1,0 +1,5 @@
+"""Pandas wrappers for drives endpoints."""
+
+from .drives_pandas import CFBDDrivesPandasAPI
+
+__all__ = ["CFBDDrivesPandasAPI"]

--- a/cfb_data/cfb_data/drives/pandas/drives_pandas.py
+++ b/cfb_data/cfb_data/drives/pandas/drives_pandas.py
@@ -1,0 +1,12 @@
+"""Pandas-returning drives API client."""
+
+import pandas as pd
+from cfb_data.base.pandas.pandas_api import CFBDPandasAPI
+
+from ..validation.drives_validation import CFBDDrivesValidationAPI
+
+
+class CFBDDrivesPandasAPI(CFBDDrivesValidationAPI, CFBDPandasAPI):
+    """Drives API client that converts responses to :class:`pandas.DataFrame`."""
+
+    pass

--- a/cfb_data/cfb_data/drives/validation/__init__.py
+++ b/cfb_data/cfb_data/drives/validation/__init__.py
@@ -1,0 +1,5 @@
+"""Export :class:`CFBDDrivesValidationAPI`."""
+
+from .drives_validation import CFBDDrivesValidationAPI
+
+__all__ = ["CFBDDrivesValidationAPI"]

--- a/cfb_data/cfb_data/drives/validation/drives_validation.py
+++ b/cfb_data/cfb_data/drives/validation/drives_validation.py
@@ -1,0 +1,11 @@
+"""Pydantic-validating drives API client."""
+
+from cfb_data.base.validation.validation_api import CFBDValidationAPI
+
+from ..api.drives_api import CFBDDrivesAPI
+
+
+class CFBDDrivesValidationAPI(CFBDDrivesAPI, CFBDValidationAPI):
+    """Drives API client that validates responses using Pydantic models."""
+
+    pass

--- a/cfb_data/cfb_data/tests/drives/api/test_drives_api.py
+++ b/cfb_data/cfb_data/tests/drives/api/test_drives_api.py
@@ -1,0 +1,61 @@
+"""Tests for the drives API layer."""
+
+import asyncio
+import importlib
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+# Provide a minimal aiohttp stub for import resolution
+importlib.import_module("sys").path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+if importlib.util.find_spec("aiohttp") is None:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    importlib.import_module("sys").modules["aiohttp"] = aiohttp_stub
+
+import pytest
+from cfb_data.drives.api.drives_api import CFBDDrivesAPI
+
+
+class DummyAPI(CFBDDrivesAPI):
+    """Subclass exposing protected methods for testing."""
+
+    def __init__(self) -> None:
+        """Initialize with a fake API key."""
+
+        super().__init__(api_key="fake")
+
+
+def run(coro):
+    """Execute ``coro`` synchronously.
+
+    :param coro: Coroutine to execute.
+    :type coro: Coroutine
+    :return: Result of the coroutine.
+    :rtype: Any
+    """
+
+    return asyncio.run(coro)
+
+
+def test_get_drives_requires_year():
+    """Ensure year parameter is enforced."""
+    api = DummyAPI()
+    with pytest.raises(ValueError):
+        run(api._get_drives({}))
+
+
+def test_get_drives_calls_make_request():
+    """Verify ``_make_request`` invocation for drives."""
+    api = DummyAPI()
+    api._make_request = AsyncMock(return_value=[{"id": "1"}])
+    params = {"year": 2024}
+    result = run(api._get_drives(params))
+    api._make_request.assert_awaited_once_with("/drives", params)
+    assert result == [{"id": "1"}]
+
+
+def test_route_map_contains_registered_path():
+    """Path decorated with :func:`route` should be registered."""
+    api = DummyAPI()
+    assert "/drives" in api._route_map

--- a/cfb_data/cfb_data/tests/drives/pandas/test_drives_pandas.py
+++ b/cfb_data/cfb_data/tests/drives/pandas/test_drives_pandas.py
@@ -1,0 +1,127 @@
+"""Tests for pandas-level drives API wrapper."""
+
+import asyncio
+import importlib
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pandera as pa
+import pytest
+
+importlib.import_module("sys").path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+if importlib.util.find_spec("aiohttp") is None:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    importlib.import_module("sys").modules["aiohttp"] = aiohttp_stub
+
+from cfb_data.base.api.base_api import route
+from cfb_data.drives.models.pandera.responses import DriveSchema
+from cfb_data.drives.models.pydantic.responses import Drive
+from cfb_data.drives.pandas import CFBDDrivesPandasAPI
+
+
+class DummyDrivesPandasAPI(CFBDDrivesPandasAPI):
+    """Expose pandas methods for testing."""
+
+    def __init__(self) -> None:
+        """Initialize the dummy API with a fake key."""
+
+        super().__init__(api_key="fake")
+
+    @route("/drives", response_model=Drive, dataframe_schema=DriveSchema)
+    async def _get_drives(self, params: dict) -> list[dict]:
+        """Proxy to ``_make_request`` for testing.
+
+        :param params: Query parameters passed to the endpoint.
+        :type params: dict
+        :return: Raw JSON list.
+        :rtype: list[dict]
+        """
+
+        return await self._make_request("/drives", params)
+
+
+def run(coro):
+    """Execute ``coro`` synchronously.
+
+    :param coro: Coroutine to execute.
+    :type coro: Coroutine
+    :return: Result of the coroutine.
+    :rtype: Any
+    """
+
+    return asyncio.run(coro)
+
+
+def test_make_request_returns_dataframe():
+    """Return DataFrame for valid drive data."""
+    sample = {
+        "offense": "A",
+        "offense_conference": None,
+        "defense": "B",
+        "defense_conference": None,
+        "game_id": 1,
+        "id": "d1",
+        "drive_number": 1,
+        "scoring": False,
+        "start_period": 1,
+        "start_yardline": 25,
+        "start_yards_to_goal": 75,
+        "start_time": {"seconds": 0, "minutes": 15},
+        "end_period": 1,
+        "end_yardline": 30,
+        "end_yards_to_goal": 70,
+        "end_time": {"seconds": 0, "minutes": 12},
+        "plays": 3,
+        "yards": 5,
+        "drive_result": "Punt",
+        "is_home_offense": True,
+        "start_offense_score": 0,
+        "start_defense_score": 0,
+        "end_offense_score": 0,
+        "end_defense_score": 0,
+    }
+    mocked = AsyncMock(return_value=[sample])
+    with patch.object(CFBDDrivesPandasAPI, "_make_request", mocked):
+        api = DummyDrivesPandasAPI()
+        df = run(api.make_request("/drives", {"year": 2024}))
+        mocked.assert_awaited_once_with("/drives", {"year": 2024})
+        assert isinstance(df, pd.DataFrame)
+        assert df.loc[0, "game_id"] == 1
+
+
+def test_make_request_schema_error():
+    """Raise schema error for invalid drive data."""
+    bad_sample = {
+        "offense": "A",
+        "offense_conference": None,
+        "defense": "B",
+        "defense_conference": None,
+        "game_id": 1,
+        "id": "d1",
+        "drive_number": 1,
+        "scoring": False,
+        "start_period": 1,
+        "start_yardline": -1,
+        "start_yards_to_goal": 101,
+        "start_time": {"seconds": 0, "minutes": 15},
+        "end_period": 1,
+        "end_yardline": 30,
+        "end_yards_to_goal": 70,
+        "end_time": {"seconds": 0, "minutes": 12},
+        "plays": 3,
+        "yards": 5,
+        "drive_result": "Punt",
+        "is_home_offense": True,
+        "start_offense_score": 0,
+        "start_defense_score": 0,
+        "end_offense_score": 0,
+        "end_defense_score": 0,
+    }
+    mocked = AsyncMock(return_value=[bad_sample])
+    with patch.object(CFBDDrivesPandasAPI, "_make_request", mocked):
+        api = DummyDrivesPandasAPI()
+        with pytest.raises(pa.errors.SchemaError):
+            run(api.make_request("/drives", {"year": 2024}))

--- a/cfb_data/cfb_data/tests/drives/validation/test_drives_validation.py
+++ b/cfb_data/cfb_data/tests/drives/validation/test_drives_validation.py
@@ -1,0 +1,87 @@
+"""Tests for validation wrapper around drives API."""
+
+import asyncio
+import importlib
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+# Provide a minimal aiohttp stub for import resolution
+importlib.import_module("sys").path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+if importlib.util.find_spec("aiohttp") is None:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    importlib.import_module("sys").modules["aiohttp"] = aiohttp_stub
+
+import pytest
+from cfb_data.drives.validation import CFBDDrivesValidationAPI
+from pydantic import ValidationError
+
+
+class DummyDrivesValidationAPI(CFBDDrivesValidationAPI):
+    """Expose protected validation methods for testing."""
+
+    def __init__(self) -> None:
+        """Initialize the dummy validation API with a fake key."""
+
+        super().__init__(api_key="fake")
+
+
+def run(coro):
+    """Execute ``coro`` synchronously.
+
+    :param coro: Coroutine to execute.
+    :type coro: Coroutine
+    :return: Result of the coroutine.
+    :rtype: Any
+    """
+
+    return asyncio.run(coro)
+
+
+def test_make_request_returns_models():
+    """Return Pydantic models when data are valid."""
+    sample = {
+        "offense": "A",
+        "offense_conference": None,
+        "defense": "B",
+        "defense_conference": None,
+        "game_id": 1,
+        "id": "d1",
+        "drive_number": 1,
+        "scoring": False,
+        "start_period": 1,
+        "start_yardline": 25,
+        "start_yards_to_goal": 75,
+        "start_time": {"seconds": 0, "minutes": 15},
+        "end_period": 1,
+        "end_yardline": 30,
+        "end_yards_to_goal": 70,
+        "end_time": {"seconds": 0, "minutes": 12},
+        "plays": 3,
+        "yards": 5,
+        "drive_result": "Punt",
+        "is_home_offense": True,
+        "start_offense_score": 0,
+        "start_defense_score": 0,
+        "end_offense_score": 0,
+        "end_defense_score": 0,
+    }
+    mocked = AsyncMock(return_value=[sample])
+    with patch.object(CFBDDrivesValidationAPI, "_make_request", mocked):
+        api = DummyDrivesValidationAPI()
+        result = run(api.make_request("/drives", {"year": 2024}))
+        mocked.assert_awaited_once_with("/drives", {"year": 2024})
+        assert isinstance(result, list)
+        assert result[0].game_id == 1
+
+
+def test_make_request_raises_on_invalid():
+    """Raise ``ValidationError`` when data are invalid."""
+    bad_sample = {"game_id": 1}
+    mocked = AsyncMock(return_value=[bad_sample])
+    with patch.object(CFBDDrivesValidationAPI, "_make_request", mocked):
+        api = DummyDrivesValidationAPI()
+        with pytest.raises(ValidationError):
+            run(api.make_request("/drives", {"year": 2024}))
+        mocked.assert_awaited_once_with("/drives", {"year": 2024})


### PR DESCRIPTION
## Summary
- implement drives API with `/drives` route
- add pydantic and pandera models for drive data
- include pandas and validation wrappers
- create tests covering API, validation, and pandas layers

## Testing
- `pytest -q`